### PR TITLE
This should fix #11 (--get-offsets-terse not displaying the correct values for some cores)

### DIFF
--- a/ryzen-smu-cli/Program.cs
+++ b/ryzen-smu-cli/Program.cs
@@ -79,12 +79,18 @@ namespace ryzen_smu_cli
                     Console.WriteLine("Current PBO offsets:");
                     string offsetLine = "";
                     bool flagNotifyDisabledCCD = false;
-                    for (int i = 0; i < mappedCores.Count; i++)
+
+                    for (int logicalCore = 0; logicalCore < mappedCores.Count; logicalCore++)
                     {
-                        int mapIndex = i < 8 ? 0 : 1;
+                        int physicalCore = mappedCores[logicalCore];
+                        int ccdIndex = (int)Math.Floor((double)(physicalCore / 8));
+                        int ccdBitmask = ccdIndex << 8;
+                        int coreNumOnCcd = physicalCore % 8;
+                        uint coreBitMask = (uint)((ccdBitmask | (coreNumOnCcd & 0xF)) << 20);
+
                         try
                         {
-                            offsetLine += Convert.ToDecimal((int)ryzen.GetPsmMarginSingleCore((uint)(((mapIndex << 8) | ((mappedCores[i] % 8) & 0xF)) << 20))!);
+                            offsetLine += Convert.ToDecimal((int)ryzen.GetPsmMarginSingleCore(coreBitMask)!);
                             offsetLine += ",";
                         }
 

--- a/ryzen-smu-cli/Program.cs
+++ b/ryzen-smu-cli/Program.cs
@@ -84,9 +84,9 @@ namespace ryzen_smu_cli
                     {
                         int physicalCore = mappedCores[logicalCore];
                         int ccdIndex = (int)Math.Floor((double)(physicalCore / 8));
-                        int ccdBitmask = ccdIndex << 8;
+                        int ccdBitMask = ccdIndex << 8;
                         int coreNumOnCcd = physicalCore % 8;
-                        uint coreBitMask = (uint)((ccdBitmask | (coreNumOnCcd & 0xF)) << 20);
+                        uint coreBitMask = (uint)((ccdBitMask | (coreNumOnCcd & 0xF)) << 20);
 
                         try
                         {

--- a/ryzen-smu-cli/ryzen-smu-cli.csproj
+++ b/ryzen-smu-cli/ryzen-smu-cli.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ryzen_smu_cli</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Also expanded the the long argument to `GetPsmMarginSingleCore` to make it more readable.