### PR TITLE
ZenStates-Core is now using PawnIO instead of WinRing0

### DIFF
--- a/ryzen-smu-cli/ryzen-smu-cli.csproj
+++ b/ryzen-smu-cli/ryzen-smu-cli.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ryzen_smu_cli</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,14 +22,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="include\ZenStates-Core\External\WinRing0\WinRing0.sys">
-        <LogicalName>ZenStates.Core.WinRing0.sys</LogicalName>
+    <EmbeddedResource Include="include\ZenStates-Core\Resources\PawnIo\AMDFamily17.bin">
+      <LogicalName>ZenStates.Core.Resources.PawnIo.AMDFamily17.bin</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="include\ZenStates-Core\External\WinRing0\WinRing0x64.sys">
-        <LogicalName>ZenStates.Core.WinRing0x64.sys</LogicalName>
+    <EmbeddedResource Include="include\ZenStates-Core\Resources\PawnIo\RyzenSMU.bin">
+      <LogicalName>ZenStates.Core.Resources.PawnIo.RyzenSMU.bin</LogicalName>
     </EmbeddedResource>
-</ItemGroup>
-
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
@@ -39,7 +38,8 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="6.0.0" />
   </ItemGroup>
+
   <Target Name="PostBuild" AfterTargets="AfterBuild" Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="xcopy /s /d /y &quot;$(ProjectDir)include\ZenStates-Core\External\InpOut\x64\inpoutx64.dll&quot; &quot;$(OutDir)&quot;&#xD;&#xA;xcopy /s /d /y &quot;$(ProjectDir)include\ZenStates-Core\External\WinIo\WinIo32.dll&quot; &quot;$(OutDir)&quot;&#xD;&#xA;xcopy /s /d /y &quot;$(ProjectDir)include\ZenStates-Core\External\WinIo\WinIo32.sys&quot; &quot;$(OutDir)&quot;&#xD;&#xA;copy &quot;$(ProjectDir)include\ZenStates-Core\External\InpOut\license.txt&quot; &quot;$(OutDir)InpOut.LICENSE.txt&quot;&#xD;&#xA;copy &quot;$(ProjectDir)include\ZenStates-Core\External\WinIo\LICENSE.txt&quot; &quot;$(OutDir)WinIo32.LICENSE.txt&quot;&#xD;&#xA;copy &quot;$(ProjectDir)include\ZenStates-Core\External\WinRing0\LICENSE.txt&quot; &quot;$(OutDir)WinRing0.LICENSE.txt&quot;" />
+    <Exec Command="xcopy /s /d /y &quot;$(ProjectDir)include\ZenStates-Core\External\InpOut\x64\inpoutx64.dll&quot; &quot;$(OutDir)&quot;&#xD;&#xA;xcopy /s /d /y &quot;$(ProjectDir)include\ZenStates-Core\External\WinIo\WinIo32.dll&quot; &quot;$(OutDir)&quot;&#xD;&#xA;xcopy /s /d /y &quot;$(ProjectDir)include\ZenStates-Core\External\WinIo\WinIo32.sys&quot; &quot;$(OutDir)&quot;&#xD;&#xA;copy &quot;$(ProjectDir)include\ZenStates-Core\External\InpOut\license.txt&quot; &quot;$(OutDir)InpOut.LICENSE.txt&quot;&#xD;&#xA;copy &quot;$(ProjectDir)include\ZenStates-Core\External\WinIo\LICENSE.txt&quot; &quot;$(OutDir)WinIo32.LICENSE.txt&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
Apparently it was enough to replace the embedded resources for the PawnIO counterparts